### PR TITLE
Keep DB connection alive

### DIFF
--- a/target_snowflake/__init__.py
+++ b/target_snowflake/__init__.py
@@ -27,7 +27,8 @@ def main(config, input_stream=None):
             warehouse=config.get('snowflake_warehouse'),
             database=config.get('snowflake_database'),
             schema=config.get('snowflake_schema', 'PUBLIC'),
-            autocommit=False
+            autocommit=False,
+            client_session_keep_alive=True
     ) as connection:
         s3_config = config.get('target_s3')
 

--- a/target_snowflake/__init__.py
+++ b/target_snowflake/__init__.py
@@ -28,7 +28,11 @@ def main(config, input_stream=None):
             database=config.get('snowflake_database'),
             schema=config.get('snowflake_schema', 'PUBLIC'),
             autocommit=False,
-            client_session_keep_alive=True
+            client_session_keep_alive=True,
+            # turn off OCSP checking to avoid disconnection in the case of very long running connections
+            # why: https://www.snowflake.com/blog/latest-changes-to-how-snowflake-handles-ocsp/
+            # doc: https://community.snowflake.com/s/article/How-to-turn-off-OCSP-checking-in-Snowflake-client-drivers
+            insecure_mode=True,
     ) as connection:
         s3_config = config.get('target_s3')
 


### PR DESCRIPTION
Introduce `client_session_keep_alive=True` to enable very long lived connections, as well as `insecure_mode=True` to disable OCSP checking that can otherwise kill a long lived connection.