### PR TITLE
Get optimizations from target-postgres dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     py_modules=['target_snowflake'],
     install_requires=[
         'singer-python==5.9.0',
-        'target_postgres@https://github.com/datamill-co/target-postgres.git#279cb62d2a80b1bd8e8ab1191e7a1d17c19383a8'
+        'target_postgres@https://github.com/datamill-co/target-postgres.git#279cb62d2a80b1bd8e8ab1191e7a1d17c19383a8',
         'target-redshift==0.2.4',
         'botocore<1.13.0,>=1.12.253',
         'snowflake-connector-python==2.2.5'

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     py_modules=['target_snowflake'],
     install_requires=[
         'singer-python==5.9.0',
-        'target_postgres@git+https://github.com/datamill-co/target-postgres.git#279cb62d2a80b1bd8e8ab1191e7a1d17c19383a8',
+        'singer-target-postgres@git+https://github.com/datamill-co/target-postgres.git#279cb62d2a80b1bd8e8ab1191e7a1d17c19383a8',
         'target-redshift==0.2.4',
         'botocore<1.13.0,>=1.12.253',
         'snowflake-connector-python==2.2.5'

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     py_modules=['target_snowflake'],
     install_requires=[
         'singer-python==5.9.0',
-        'singer-target-postgres==0.2.4',
+        'target_postgres@git+ssh://git@github.com/datamill-co/target-postgres.git#279cb62d2a80b1bd8e8ab1191e7a1d17c19383a8'
         'target-redshift==0.2.4',
         'botocore<1.13.0,>=1.12.253',
         'snowflake-connector-python==2.2.5'

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     py_modules=['target_snowflake'],
     install_requires=[
         'singer-python==5.9.0',
-        'target_postgres@git+ssh://git@github.com/datamill-co/target-postgres.git#279cb62d2a80b1bd8e8ab1191e7a1d17c19383a8'
+        'target_postgres@https://github.com/datamill-co/target-postgres.git#279cb62d2a80b1bd8e8ab1191e7a1d17c19383a8'
         'target-redshift==0.2.4',
         'botocore<1.13.0,>=1.12.253',
         'snowflake-connector-python==2.2.5'

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     py_modules=['target_snowflake'],
     install_requires=[
         'singer-python==5.9.0',
-        'target_postgres@https://github.com/datamill-co/target-postgres.git#279cb62d2a80b1bd8e8ab1191e7a1d17c19383a8',
+        'target_postgres@git+https://github.com/datamill-co/target-postgres.git#279cb62d2a80b1bd8e8ab1191e7a1d17c19383a8',
         'target-redshift==0.2.4',
         'botocore<1.13.0,>=1.12.253',
         'snowflake-connector-python==2.2.5'

--- a/target_snowflake/snowflake.py
+++ b/target_snowflake/snowflake.py
@@ -22,7 +22,7 @@ from target_snowflake import sql
 from target_snowflake.connection import connect
 from target_snowflake.exceptions import SnowflakeError
 
-# copied in from optimization in TargetPostgres: https://github.com/datamill-co/target-postgres/commit/6a3da026d2bb4681fdf46bd7ca69fbb164489d8a
+# copied in from optimization in PostgresTarget: https://github.com/datamill-co/target-postgres/commit/6a3da026d2bb4681fdf46bd7ca69fbb164489d8a
 @lru_cache(maxsize=128)
 def _format_datetime(value):
     """

--- a/target_snowflake/snowflake.py
+++ b/target_snowflake/snowflake.py
@@ -545,8 +545,11 @@ class SnowflakeTarget(SQLInterface):
             subkeys)
 
     def write_table_batch(self, cur, table_batch, metadata):
-        remote_schema = table_batch['remote_schema']
+        record_count = len(table_batch['records'])
+        if record_count == 0:
+            return 0
 
+        remote_schema = table_batch['remote_schema']
 
         ## Create temp table to upload new data to
         target_table_name = self.canonicalize_identifier('tmp_' + str(uuid.uuid4()))
@@ -586,7 +589,7 @@ class SnowflakeTarget(SQLInterface):
                               csv_headers,
                               csv_rows)
 
-        return len(table_batch['records'])
+        return record_count
 
     def add_column(self, cur, table_name, column_name, column_schema):
         cur.execute('''


### PR DESCRIPTION
Update the target-postgres dependency to get the latest `master` branch commit, which is many commits ahead of the `0.2.4` package version. This provides several performance optimizations that have been added, such as:
* Multiple optimizations: https://github.com/datamill-co/target-postgres/pull/204
* Reduce state message memory footprint: https://github.com/datamill-co/target-postgres/pull/212

Additionally, bypass table insertion work when the record count is zero. The code still respects the `persist_empty_tables` setting to manage the table schema itself, but will not go through the expensive process to perform a zero-record insertion. That process takes ~6s per table, which in the GitHub tap means a few minutes of completely wasted time for an ETL process which has little-to-no new data.

# Testing
Tested locally with tap-github running on minwareco/repotest, which brought runtime down from ~1m45s to ~40s. Also, most of that remaining run time will be eliminated when https://minware.atlassian.net/browse/MW-496 is completed, which causes only one GitHub ingest pipeline per org to process the global data (e.g. collaborators, issues).